### PR TITLE
Ensure that aperture shutter position values cannot be negative.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -7,6 +7,19 @@ Version History
 ###############
 
 =======
+v1.18.2
+=======
+* Ensure that aperture shutter position values cannot be negative.
+
+Requires:
+
+* ts_salobj 7
+* ts_idl
+* ts_tcpip 2.0
+* ts_utils 1.2
+* ts_xml 22.0
+
+=======
 v1.18.1
 =======
 * Fix status command errors.

--- a/tests/test_apscs.py
+++ b/tests/test_apscs.py
@@ -76,7 +76,7 @@ class ApscsTestCase(unittest.IsolatedAsyncioTestCase):
         """
         await self.apscs.determine_status(current_tai=tai)
         assert [expected_position] * NUM_SHUTTERS == pytest.approx(
-            self.apscs.llc_status["positionActual"]
+            self.apscs.llc_status["positionActual"], abs=0.001
         )
         assert [expected_motion_state.name] * NUM_SHUTTERS == self.apscs.llc_status[
             "status"

--- a/tests/test_mtdome_csc.py
+++ b/tests/test_mtdome_csc.py
@@ -638,6 +638,14 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 MotionState.PROXIMITY_CLOSED_LS_ENGAGED.name,
                 MotionState.PROXIMITY_CLOSED_LS_ENGAGED.name,
             ]
+            telemetry = await self.assert_next_sample(
+                topic=self.remote.tel_apertureShutter
+            )
+            assert math.isclose(telemetry.positionActual[0], 0.0)
+            assert math.isclose(telemetry.positionActual[1], 0.0)
+            # Assert there are no -0.0 values.
+            assert math.copysign(1, telemetry.positionActual[0]) > 0
+            assert math.copysign(1, telemetry.positionActual[1]) > 0
 
     async def test_do_stopShutter(self) -> None:
         async with self.make_csc(
@@ -1135,7 +1143,8 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 mtdome.InternalMotionState.STATIONARY.name,
                 mtdome.InternalMotionState.STATIONARY.name,
             ]
-            assert apscs_status["positionActual"] == [0.0, 0.0]
+            assert math.isclose(apscs_status["positionActual"][0], 0.0, abs_tol=0.001)
+            assert math.isclose(apscs_status["positionActual"][1], 0.0, abs_tol=0.001)
 
             await self.csc.statusLCS()
             lcs_status = self.csc.lower_level_status[mtdome.LlcName.LCS.value]


### PR DESCRIPTION
I implemented a jitter around the position of the aperture shutter. Then I implemented code that rounds off telemetry values to a certain amount of decimals and made sure that any `-0.0` values will be `0.0`.